### PR TITLE
get rid of sqlite3 mention in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The objectively best Twitter video downloader bot.
 [If you want to self-host this, I suggest doing these things.](https://twitter.com/TheEssem/status/1179800410120474625)
 
 ## Usage
-Requires Node.js, FFmpeg, and SQLite3:
+Requires Node.js, FFmpeg, and frei0r-plugins:
 
 ```shell
 sudo apt install nodejs ffmpeg frei0r-plugins


### PR DESCRIPTION
why is this still here